### PR TITLE
Fix android breaking change RN >= 0.47

### DIFF
--- a/android/src/main/java/com/pilloxa/dfu/RNNordicDfuPackage.java
+++ b/android/src/main/java/com/pilloxa/dfu/RNNordicDfuPackage.java
@@ -17,11 +17,6 @@ public class RNNordicDfuPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();
     }


### PR DESCRIPTION
React Native 0.47 removed createJSModules on Android https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8#diff-63e621165603dc1a84832d6c400fae31 (fixes #10 )

I've also tested to do firmware upgrade after this and it worked just fine