### PR TITLE
Remove @Override annotation in RNNordicDfuPackage

### DIFF
--- a/android/src/main/java/com/pilloxa/dfu/RNNordicDfuPackage.java
+++ b/android/src/main/java/com/pilloxa/dfu/RNNordicDfuPackage.java
@@ -16,7 +16,6 @@ public class RNNordicDfuPackage implements ReactPackage {
       return Arrays.<NativeModule>asList(new RNNordicDfuModule(reactContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
       return Collections.emptyList();
     }


### PR DESCRIPTION
Since RN@0.47 (see https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) the `@Override` annotation is no longer welcomed by the compiler as the function was removed.

And please make a release with this change if possible 👍
Fixes #10 