### PR TITLE
Support React Installed From CocoaPods

### DIFF
--- a/ios/RNNordicDfu.xcodeproj/project.pbxproj
+++ b/ios/RNNordicDfu.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(PROJECT_DIR)/iOSDFULibrary.framework/**",
+					"$(PROJECT_DIR)/../../../ios/Pods/Headers/Public",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -221,6 +222,7 @@
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(PROJECT_DIR)/iOSDFULibrary.framework/**",
+					"$(PROJECT_DIR)/../../../ios/Pods/Headers/Public",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";

--- a/ios/RNNordicDfu.xcodeproj/project.pbxproj
+++ b/ios/RNNordicDfu.xcodeproj/project.pbxproj
@@ -203,7 +203,7 @@
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(PROJECT_DIR)/iOSDFULibrary.framework/**",
-					"$(PROJECT_DIR)/../../../ios/Pods/Headers/Public",
+					"$(PROJECT_DIR)/../../../ios/Pods/Headers/Public/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
@@ -222,7 +222,7 @@
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 					"$(PROJECT_DIR)/iOSDFULibrary.framework/**",
-					"$(PROJECT_DIR)/../../../ios/Pods/Headers/Public",
+					"$(PROJECT_DIR)/../../../ios/Pods/Headers/Public/**",
 				);
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";


### PR DESCRIPTION
Adds the proper header search path for users who installed React into their project via CocoaPods.  The change assumes a standard react-native directory structure.

Fixes #37