### PR TITLE
add alternativeAdvertisingNameEnabled param to startDFU

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ This is an unofficial fork and is NOT actively maintained.
 Install and link the NPM package per usual with
 
 ```bash
-npm install --save react-native-nordic-dfu
-react-native link react-native-nordic-dfu
+npm install --save react-native-nordic-dfu-aan-patch
+react-native link react-native-nordic-dfu-aan-patch
 ```
 
 ### Minimum requirements

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@ nrf52 chip from Nordic Semiconductor. It works for both iOS and Android.
 
 For more info about the DFU process, see: [Resources](#resources)
 
+## Alternative Advertising Name (AAN) patch
+
+Hello! This is a fork of the [react-native-nordic-dfu](https://github.com/Pilloxa/react-native-nordic-dfu) repo.
+This is an unofficial fork and is NOT actively maintained.
+
 ## Installation
 
 Install and link the NPM package per usual with

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,11 +3,13 @@ declare module 'react-native-nordic-dfu' {
     static startDFU({
       deviceAddress,
       deviceName,
-      filePath
+      filePath,
+      alternativeAdvertisingNameEnabled
     }: {
       deviceAddress: string;
       deviceName?: string;
       filePath: string | null;
+      alternativeAdvertisingNameEnabled?: boolean;
     }): Promise<string>;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'react-native-nordic-dfu' {
+declare module 'react-native-nordic-dfu-aan-patch' {
   export class NordicDFU {
     static startDFU({
       deviceAddress,

--- a/index.js
+++ b/index.js
@@ -17,11 +17,14 @@ function rejectPromise(message) {
  * the actual connect and then the transfer. See the example project to see how it can be
  * done in React Native.
  *
+ * For `alternativeAdvertisingNameEnabled` option below, see:
+ * https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/blob/master/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift#L191
  *
  * @param {Object} obj
  * @param {string} obj.deviceAddress The MAC address for the device that should be updated
  * @param {string} [obj.deviceName = null] The name of the device in the update notification
  * @param {string} obj.filePath The file system path to the zip-file used for updating
+ * @param {Boolean} obj.alternativeAdvertisingNameEnabled Send unique name to device before it is switched into bootloader mode
  * @returns {Promise} A promise that resolves or rejects with the `deviceAddress` in the return value
  *
  * @example
@@ -35,7 +38,12 @@ function rejectPromise(message) {
  *   .then(res => console.log("Transfer done:", res))
  *   .catch(console.log);
  */
-function startDFU({ deviceAddress, deviceName = null, filePath }) {
+function startDFU({
+  deviceAddress,
+  deviceName = null,
+  filePath,
+  alternativeAdvertisingNameEnabled = true
+}) {
   if (deviceAddress == undefined) {
     return rejectPromise("No deviceAddress defined");
   }
@@ -43,7 +51,7 @@ function startDFU({ deviceAddress, deviceName = null, filePath }) {
     return rejectPromise("No filePath defined");
   }
   const upperDeviceAddress = deviceAddress.toUpperCase();
-  return RNNordicDfu.startDFU(upperDeviceAddress, deviceName, filePath);
+  return RNNordicDfu.startDFU(upperDeviceAddress, deviceName, filePath, alternativeAdvertisingNameEnabled);
 }
 
 /**

--- a/ios/RNNordicDfu.m
+++ b/ios/RNNordicDfu.m
@@ -185,6 +185,7 @@ didOccurWithMessage:(NSString * _Nonnull)message
 RCT_EXPORT_METHOD(startDFU:(NSString *)deviceAddress
                   deviceName:(NSString *)deviceName
                   filePath:(NSString *)filePath
+                  alternativeAdvertisingNameEnabled:(BOOL *)alternativeAdvertisingNameEnabled
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -225,6 +226,7 @@ RCT_EXPORT_METHOD(startDFU:(NSString *)deviceAddress
         initiator.logger = self;
         initiator.delegate = self;
         initiator.progressDelegate = self;
+        initiator.alternativeAdvertisingNameEnabled = alternativeAdvertisingNameEnabled;
 
         DFUServiceController * controller = [initiator start];
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nordic-dfu-aan-patch",
-  "version": "3.0.1-aan-patch-beta",
+  "version": "3.0.1-aan-patch-1.1",
   "description": "Nordic Device Firmware Update for React Native",
   "main": "index.js",
   "url": "https://github.com/townofdon/react-native-nordic-dfu",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nordic-dfu-aan-patch",
-  "version": "3.0.1-aan-patch-1.1",
+  "version": "3.0.1-aan-patch-1.2",
   "description": "Nordic Device Firmware Update for React Native",
   "main": "index.js",
   "url": "https://github.com/townofdon/react-native-nordic-dfu",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "react-native-nordic-dfu-aan-patch",
-  "version": "3.0.1-aan-patch",
+  "version": "3.0.1-aan-patch-beta",
   "description": "Nordic Device Firmware Update for React Native",
   "main": "index.js",
-  "url": "https://github.com/Pilloxa/react-native-nordic-dfu",
-  "repository": "Pilloxa/react-native-nordic-dfu",
+  "url": "https://github.com/townofdon/react-native-nordic-dfu",
+  "repository": "townofdon/react-native-nordic-dfu",
   "scripts": {
     "test": "echo \"No test specified\"",
     "precommit": "lint-staged",
@@ -15,7 +15,7 @@
     "dfu",
     "nordic"
   ],
-  "author": "Pilloxa <recruitment@pilloxa.com>",
+  "author": "townofdon <townofdon@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
     "react-native": ">= 0.45.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nordic-dfu",
-  "version": "3.0.1",
+  "version": "3.0.1-aan-patch",
   "description": "Nordic Device Firmware Update for React Native",
   "main": "index.js",
   "url": "https://github.com/Pilloxa/react-native-nordic-dfu",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-nordic-dfu-aan-patch",
-  "version": "3.0.1-aan-patch-1.2",
+  "version": "3.0.1-aan-patch-1.3",
   "description": "Nordic Device Firmware Update for React Native",
   "main": "index.js",
   "url": "https://github.com/townofdon/react-native-nordic-dfu",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "react-native-nordic-dfu",
+  "name": "react-native-nordic-dfu-aan-patch",
   "version": "3.0.1-aan-patch",
   "description": "Nordic Device Firmware Update for React Native",
   "main": "index.js",

--- a/react-native-nordic-dfu-aan-patch.podspec
+++ b/react-native-nordic-dfu-aan-patch.podspec
@@ -7,12 +7,12 @@ Pod::Spec.new do |s|
   s.version      = package['version']
   s.summary      = package['description']
 
-  s.authors      = { "Pilloxa" => "recruitment@pilloxa.com" }
-  s.homepage     = "https://github.com/Pilloxa/react-native-nordic-dfu"
+  s.authors      = { "townofdon" => "townofdon@gmail.com" }
+  s.homepage     = "https://github.com/townofdon/react-native-nordic-dfu"
   s.license      = "Apache License 2.0"
   s.platform     = :ios, "8.0"
 
-  s.source       = { :git => "https://github.com/Pilloxa/react-native-nordic-dfu.git" }
+  s.source       = { :git => "https://github.com/townofdon/react-native-nordic-dfu.git" }
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'

--- a/react-native-nordic-dfu-aan-patch.podspec
+++ b/react-native-nordic-dfu-aan-patch.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name         = "react-native-nordic-dfu"
+  s.name         = "react-native-nordic-dfu-aan-patch"
   s.version      = package['version']
   s.summary      = package['description']
 


### PR DESCRIPTION
For my use-case we needed to disable `alternativeAdvertisingNameEnabled`. This PR provides this optional param for the `startDFU` method.

Since this is a setting available on the nRF Connect app, it makes sense that it should also be available here. See: https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/blob/master/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift#L191