### PR TITLE
add alternativeAdvertisingNameEnabled param to startDFU

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ done in React Native.
     -   `obj.deviceAddress` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The `identifier`\* of the device that should be updated
     -   `obj.deviceName` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the device in the update notification (optional, default `null`)
     -   `obj.filePath` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The file system path to the zip-file used for updating
+    -   `obj.alternativeAdvertisingNameEnabled` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Send unique name to device before it is switched into bootloader mode (iOS only) - defaults to `true`
 
 \* `identifier` — MAC address (Android) / UUID (iOS)
 

--- a/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
+++ b/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
@@ -30,7 +30,7 @@ public class RNNordicDfuModule extends ReactContextBaseJavaModule implements Lif
     }
 
     @ReactMethod
-    public void startDFU(String address, String name, String filePath, Promise promise) {
+    public void startDFU(String address, String name, String filePath, Boolean _alternativeAdvertisingNameEnabled, Promise promise) {
         mPromise = promise;
         final DfuServiceInitiator starter = new DfuServiceInitiator(address)
                 .setKeepBond(false);

--- a/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
+++ b/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
@@ -30,7 +30,7 @@ public class RNNordicDfuModule extends ReactContextBaseJavaModule implements Lif
     }
 
     @ReactMethod
-    public void startDFU(String address, String name, String filePath, Boolean _alternativeAdvertisingNameEnabled, Promise promise) {
+    public void startDFU(String address, String name, String filePath, Promise promise) {
         mPromise = promise;
         final DfuServiceInitiator starter = new DfuServiceInitiator(address)
                 .setKeepBond(false);

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,11 +3,13 @@ declare module 'react-native-nordic-dfu' {
     static startDFU({
       deviceAddress,
       deviceName,
-      filePath
+      filePath,
+      alternativeAdvertisingNameEnabled
     }: {
       deviceAddress: string;
       deviceName?: string;
       filePath: string | null;
+      alternativeAdvertisingNameEnabled?: boolean;
     }): Promise<string>;
   }
 

--- a/index.js
+++ b/index.js
@@ -17,11 +17,14 @@ function rejectPromise(message) {
  * the actual connect and then the transfer. See the example project to see how it can be
  * done in React Native.
  *
+ * For `alternativeAdvertisingNameEnabled` option below, see:
+ * https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/blob/master/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift#L191
  *
  * @param {Object} obj
  * @param {string} obj.deviceAddress The MAC address for the device that should be updated
  * @param {string} [obj.deviceName = null] The name of the device in the update notification
  * @param {string} obj.filePath The file system path to the zip-file used for updating
+ * @param {Boolean} obj.alternativeAdvertisingNameEnabled Send unique name to device before it is switched into bootloader mode
  * @returns {Promise} A promise that resolves or rejects with the `deviceAddress` in the return value
  *
  * @example
@@ -35,7 +38,12 @@ function rejectPromise(message) {
  *   .then(res => console.log("Transfer done:", res))
  *   .catch(console.log);
  */
-function startDFU({ deviceAddress, deviceName = null, filePath }) {
+function startDFU({
+  deviceAddress,
+  deviceName = null,
+  filePath,
+  alternativeAdvertisingNameEnabled = true
+}) {
   if (deviceAddress == undefined) {
     return rejectPromise("No deviceAddress defined");
   }
@@ -43,7 +51,7 @@ function startDFU({ deviceAddress, deviceName = null, filePath }) {
     return rejectPromise("No filePath defined");
   }
   const upperDeviceAddress = deviceAddress.toUpperCase();
-  return RNNordicDfu.startDFU(upperDeviceAddress, deviceName, filePath);
+  return RNNordicDfu.startDFU(upperDeviceAddress, deviceName, filePath, alternativeAdvertisingNameEnabled);
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function rejectPromise(message) {
  * @param {string} obj.deviceAddress The MAC address for the device that should be updated
  * @param {string} [obj.deviceName = null] The name of the device in the update notification
  * @param {string} obj.filePath The file system path to the zip-file used for updating
- * @param {Boolean} obj.alternativeAdvertisingNameEnabled Send unique name to device before it is switched into bootloader mode
+ * @param {Boolean} obj.alternativeAdvertisingNameEnabled Send unique name to device before it is switched into bootloader mode (iOS only)
  * @returns {Promise} A promise that resolves or rejects with the `deviceAddress` in the return value
  *
  * @example
@@ -51,7 +51,10 @@ function startDFU({
     return rejectPromise("No filePath defined");
   }
   const upperDeviceAddress = deviceAddress.toUpperCase();
-  return RNNordicDfu.startDFU(upperDeviceAddress, deviceName, filePath, alternativeAdvertisingNameEnabled);
+  if (Platform.OS === 'ios') {
+    return RNNordicDfu.startDFU(upperDeviceAddress, deviceName, filePath, alternativeAdvertisingNameEnabled);
+  }
+  return RNNordicDfu.startDFU(upperDeviceAddress, deviceName, filePath);
 }
 
 /**

--- a/ios/RNNordicDfu.m
+++ b/ios/RNNordicDfu.m
@@ -185,6 +185,7 @@ didOccurWithMessage:(NSString * _Nonnull)message
 RCT_EXPORT_METHOD(startDFU:(NSString *)deviceAddress
                   deviceName:(NSString *)deviceName
                   filePath:(NSString *)filePath
+                  alternativeAdvertisingNameEnabled:(BOOL *)alternativeAdvertisingNameEnabled
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {
@@ -225,6 +226,7 @@ RCT_EXPORT_METHOD(startDFU:(NSString *)deviceAddress
         initiator.logger = self;
         initiator.delegate = self;
         initiator.progressDelegate = self;
+        initiator.alternativeAdvertisingNameEnabled = alternativeAdvertisingNameEnabled;
 
         DFUServiceController * controller = [initiator start];
       }


### PR DESCRIPTION
This makes `alternativeAdvertisingNameEnabled` configurable.

See reason for this [here](https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/pull/160).

It looks like this param was only needed on iOS - as you can see the param in the Android file is unused. I didn't see a good way around this and am open to suggestions!