### PR TITLE
Update iOS dependencies

### DIFF
--- a/react-native-nordic-dfu.podspec
+++ b/react-native-nordic-dfu.podspec
@@ -16,6 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'ZIPFoundation', '~> 0.9.8'
-  s.dependency 'iOSDFULibrary', '~> 4.4.0'
+  s.dependency 'iOSDFULibrary', '~> 4.7.1'
 end


### PR DESCRIPTION
- Update iOSDFULibrary to latest version
- Remove ZIPFoundation as a direct dependency as it is a sub-dependency of iOSDFULibrary already