### PR TITLE
add packetReceiptNotificationParameter to startDFU

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ done in React Native.
   - `obj.deviceAddress` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The `identifier`\* of the device that should be updated
   - `obj.deviceName` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The name of the device in the update notification (optional, default `null`)
   - `obj.filePath` **[string](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** The file system path to the zip-file used for updating
+  - `obj.packetReceiptNotificationParameter` **[number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number)** set number of packets of firmware data to be received by the DFU target before sending a new Packet Receipt Notification - defaults to `12`
   - `obj.alternativeAdvertisingNameEnabled` **[boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** Send unique name to device before it is switched into bootloader mode (iOS only) - defaults to `true`
 
 \* `identifier` — MAC address (Android) / UUID (iOS)

--- a/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
+++ b/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
@@ -39,7 +39,12 @@ public class RNNordicDfuModule extends ReactContextBaseJavaModule implements Lif
         }
         starter.setUnsafeExperimentalButtonlessServiceInSecureDfuEnabled(true);
         starter.setZip(filePath);
-        starter.setPacketReceiptNotificationParameter(packetReceiptNotificationParameter);
+        // mimic behavior of iOSDFULibrary when packetReceiptNotificationParameter is set to `0` - see: https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/blob/master/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift#L115
+        if (packetReceiptNotificationParameter > 0) {
+          starter.setPacketsReceiptNotificationsValue(packetReceiptNotificationParameter);
+        } else {
+          starter.setPacketsReceiptNotificationsEnabled(false);
+        }
         final DfuServiceController controller = starter.start(this.reactContext, DfuService.class);
     }
 

--- a/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
+++ b/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
@@ -30,7 +30,7 @@ public class RNNordicDfuModule extends ReactContextBaseJavaModule implements Lif
     }
 
     @ReactMethod
-    public void startDFU(String address, String name, String filePath, Promise promise) {
+    public void startDFU(String address, String name, String filePath, int packetReceiptNotificationParameter, Promise promise) {
         mPromise = promise;
         final DfuServiceInitiator starter = new DfuServiceInitiator(address)
                 .setKeepBond(false);
@@ -39,6 +39,7 @@ public class RNNordicDfuModule extends ReactContextBaseJavaModule implements Lif
         }
         starter.setUnsafeExperimentalButtonlessServiceInSecureDfuEnabled(true);
         starter.setZip(filePath);
+        starter.setPacketReceiptNotificationParameter = packetReceiptNotificationParameter;
         final DfuServiceController controller = starter.start(this.reactContext, DfuService.class);
     }
 

--- a/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
+++ b/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
@@ -39,7 +39,7 @@ public class RNNordicDfuModule extends ReactContextBaseJavaModule implements Lif
         }
         starter.setUnsafeExperimentalButtonlessServiceInSecureDfuEnabled(true);
         starter.setZip(filePath);
-        starter.setPacketReceiptNotificationParameter = packetReceiptNotificationParameter;
+        starter.setPacketReceiptNotificationParameter(packetReceiptNotificationParameter);
         final DfuServiceController controller = starter.start(this.reactContext, DfuService.class);
     }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,12 +4,14 @@ declare module 'react-native-nordic-dfu' {
       deviceAddress,
       deviceName,
       filePath,
-      alternativeAdvertisingNameEnabled
+      alternativeAdvertisingNameEnabled,
+      packetReceiptNotificationParameter
     }: {
       deviceAddress: string;
       deviceName?: string;
       filePath: string | null;
       alternativeAdvertisingNameEnabled?: boolean;
+      packetReceiptNotificationParameter?: number;
     }): Promise<string>;
   }
 

--- a/index.js
+++ b/index.js
@@ -25,6 +25,7 @@ function rejectPromise(message) {
  * @param {string} [obj.deviceName = null] The name of the device in the update notification
  * @param {string} obj.filePath The file system path to the zip-file used for updating
  * @param {Boolean} obj.alternativeAdvertisingNameEnabled Send unique name to device before it is switched into bootloader mode (iOS only)
+ * @param {number} obj.packetReceiptNotificationParameter set number of packets of firmware data to be received by the DFU target before sending a new Packet Receipt Notification
  * @returns {Promise} A promise that resolves or rejects with the `deviceAddress` in the return value
  *
  * @example
@@ -42,7 +43,8 @@ function startDFU({
   deviceAddress,
   deviceName = null,
   filePath,
-  alternativeAdvertisingNameEnabled = true
+  alternativeAdvertisingNameEnabled = true,
+  packetReceiptNotificationParameter = 12,
 }) {
   if (deviceAddress == undefined) {
     return rejectPromise("No deviceAddress defined");
@@ -52,9 +54,9 @@ function startDFU({
   }
   const upperDeviceAddress = deviceAddress.toUpperCase();
   if (Platform.OS === 'ios') {
-    return RNNordicDfu.startDFU(upperDeviceAddress, deviceName, filePath, alternativeAdvertisingNameEnabled);
+    return RNNordicDfu.startDFU(upperDeviceAddress, deviceName, filePath, packetReceiptNotificationParameter, alternativeAdvertisingNameEnabled);
   }
-  return RNNordicDfu.startDFU(upperDeviceAddress, deviceName, filePath);
+  return RNNordicDfu.startDFU(upperDeviceAddress, deviceName, filePath, packetReceiptNotificationParameter);
 }
 
 /**

--- a/ios/RNNordicDfu.m
+++ b/ios/RNNordicDfu.m
@@ -185,6 +185,7 @@ didOccurWithMessage:(NSString * _Nonnull)message
 RCT_EXPORT_METHOD(startDFU:(NSString *)deviceAddress
                   deviceName:(NSString *)deviceName
                   filePath:(NSString *)filePath
+                  packetReceiptNotificationParameter:(NSInteger *)packetReceiptNotificationParameter
                   alternativeAdvertisingNameEnabled:(BOOL *)alternativeAdvertisingNameEnabled
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
@@ -226,6 +227,7 @@ RCT_EXPORT_METHOD(startDFU:(NSString *)deviceAddress
         initiator.logger = self;
         initiator.delegate = self;
         initiator.progressDelegate = self;
+        initiator.packetReceiptNotificationParameter = packetReceiptNotificationParameter;
         initiator.alternativeAdvertisingNameEnabled = alternativeAdvertisingNameEnabled;
 
         DFUServiceController * controller = [initiator start];


### PR DESCRIPTION
This PR adds the `packetReceiptNotificationParameter` parameter to the `startDFU` method.

This should resolve issue #113  

Reason:
- We had users experiencing this error when trying to perform firmware updates: `Error in startDFU Error: 7024 bytes were sent while 0 bytes were reported as received`
- The IOS-Pods-DFU-Library lib allows for `packetReceiptNotificationParameter` to be configured as needed. See details here: https://github.com/NordicSemiconductor/IOS-Pods-DFU-Library/blob/master/iOSDFULibrary/Classes/Implementation/DFUServiceInitiator.swift#L115
- See #113 for a more detailed explanation of this issue

@Looveh  Please let me know if any tweaks need to be made!
