### PR TITLE
iOSDFULibrary version to ~> 4.11.0

### DIFF
--- a/react-native-nordic-dfu.podspec
+++ b/react-native-nordic-dfu.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'iOSDFULibrary', '~> 4.7.1'
+  s.dependency 'iOSDFULibrary', '~> 4.11.0'
 end


### PR DESCRIPTION
- update iOSDFULibrary to fix Xcode 13 build issue