### PR TITLE
Update iOSDFULibrary to fix compilation errors on XCode 13

### DIFF
--- a/react-native-nordic-dfu.podspec
+++ b/react-native-nordic-dfu.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/**/*.{h,m}"
 
   s.dependency 'React'
-  s.dependency 'iOSDFULibrary', '~> 4.7.1'
+  s.dependency 'iOSDFULibrary', '~> 4.11.1'
 end


### PR DESCRIPTION
iOSDFULibrary released today a new version to fix the compilation errors on XCode 13.