### PR TITLE
Revive unpushed changes out of NPM

### DIFF
--- a/android/src/main/java/com/pilloxa/dfu/NotificationActivity.java
+++ b/android/src/main/java/com/pilloxa/dfu/NotificationActivity.java
@@ -3,7 +3,7 @@ package com.pilloxa.dfu;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.bridge.ReactContext;

--- a/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
+++ b/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
@@ -5,7 +5,7 @@ import android.app.NotificationManager;
 import android.content.Context;
 import android.os.Build;
 import android.os.Handler;
-import android.support.annotation.Nullable;
+import androidx.annotation.Nullable;
 import android.util.Log;
 import com.facebook.react.bridge.*;
 import com.facebook.react.modules.core.RCTNativeAppEventEmitter;


### PR DESCRIPTION
We've had some staff changes at Pilloxa and I'm new to this project.

Seems like the version published to NPM is at 3.2.0 and this repo is only at 3.1.0.  Sounds like some changes were published to NPM without pushing to GitHub unfortunately. I've downloaded the contents of the 3.2.0 release from NPM and these are the changes.

I'm missing context on this, could anyone review / give some insights about this?